### PR TITLE
Added support for PharoSmalltalkInteropServer v2.0.0

### DIFF
--- a/pharo_smalltalk_interop_mcp_server/core.py
+++ b/pharo_smalltalk_interop_mcp_server/core.py
@@ -38,24 +38,10 @@ class PharoClient:
         except httpx.RequestError as e:
             return {"success": False, "error": f"Connection error: {e}"}
         except httpx.HTTPStatusError as e:
-            try:
-                # Try to parse response body as JSON for detailed error info
-                error_response = e.response.json()
-                if isinstance(error_response, dict) and "error" in error_response:
-                    # Return the detailed error response as-is if it has the expected structure
-                    return {"success": False, **error_response}
-                else:
-                    # Fallback to simple error message
-                    return {
-                        "success": False,
-                        "error": f"HTTP error {e.response.status_code}: {e.response.text}",
-                    }
-            except json.JSONDecodeError:
-                # Fallback to simple error message if response is not valid JSON
-                return {
-                    "success": False,
-                    "error": f"HTTP error {e.response.status_code}: {e.response.text}",
-                }
+            return {
+                "success": False,
+                "error": f"HTTP error {e.response.status_code}: {e.response.text}",
+            }
         except json.JSONDecodeError as e:
             return {"success": False, "error": f"Invalid JSON response: {e}"}
 

--- a/pharo_smalltalk_interop_mcp_server/core.py
+++ b/pharo_smalltalk_interop_mcp_server/core.py
@@ -38,10 +38,24 @@ class PharoClient:
         except httpx.RequestError as e:
             return {"success": False, "error": f"Connection error: {e}"}
         except httpx.HTTPStatusError as e:
-            return {
-                "success": False,
-                "error": f"HTTP error {e.response.status_code}: {e.response.text}",
-            }
+            try:
+                # Try to parse response body as JSON for detailed error info
+                error_response = e.response.json()
+                if isinstance(error_response, dict) and "error" in error_response:
+                    # Return the detailed error response as-is if it has the expected structure
+                    return {"success": False, **error_response}
+                else:
+                    # Fallback to simple error message
+                    return {
+                        "success": False,
+                        "error": f"HTTP error {e.response.status_code}: {e.response.text}",
+                    }
+            except json.JSONDecodeError:
+                # Fallback to simple error message if response is not valid JSON
+                return {
+                    "success": False,
+                    "error": f"HTTP error {e.response.status_code}: {e.response.text}",
+                }
         except json.JSONDecodeError as e:
             return {"success": False, "error": f"Invalid JSON response: {e}"}
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -876,25 +876,22 @@ class TestEnhancedErrorHandling:
 
     @patch("pharo_smalltalk_interop_mcp_server.core.httpx.Client")
     def test_make_request_with_enhanced_error_response(self, mock_client_class):
-        """Test _make_request handling enhanced error response format."""
+        """Test _make_request handling enhanced error response format (HTTP 200)."""
         mock_client = Mock()
         mock_response = Mock()
-        mock_response.status_code = 500
-        mock_response.text = "Internal Server Error"
+        mock_response.status_code = 200
 
-        # Enhanced error response format
+        # Enhanced error response format (returned as HTTP 200 by Pharo server)
         enhanced_error = {
+            "success": False,
             "error": {
                 "description": "ZeroDivide: division by zero",
                 "stack_trace": "SmallInteger>>/ (SmallInteger.class:123)\nUndefinedObject>>DoIt (DoIt.class:1)\nCompiler>>evaluate:in: (Compiler.class:456)",
                 "receiver": {"class": "SmallInteger", "self": "1", "variables": {}},
-            }
+            },
         }
         mock_response.json.return_value = enhanced_error
-
-        mock_client.post.side_effect = httpx.HTTPStatusError(
-            "Server Error", request=Mock(), response=mock_response
-        )
+        mock_client.post.return_value = mock_response
         mock_client_class.return_value = mock_client
 
         client = PharoClient()
@@ -912,37 +909,32 @@ class TestEnhancedErrorHandling:
 
     @patch("pharo_smalltalk_interop_mcp_server.core.httpx.Client")
     def test_make_request_with_simple_error_response(self, mock_client_class):
-        """Test _make_request handling simple error response format (backward compatibility)."""
+        """Test _make_request handling simple error response format (HTTP 200, backward compatibility)."""
         mock_client = Mock()
         mock_response = Mock()
-        mock_response.status_code = 500
-        mock_response.text = "Internal Server Error"
+        mock_response.status_code = 200
 
-        # Simple error response format
-        simple_error = {"error": "Class not found: NonExistentClass"}
+        # Simple error response format (returned as HTTP 200 by Pharo server)
+        simple_error = {"success": False, "error": "Class not found: NonExistentClass"}
         mock_response.json.return_value = simple_error
-
-        mock_client.post.side_effect = httpx.HTTPStatusError(
-            "Server Error", request=Mock(), response=mock_response
-        )
+        mock_client.get.return_value = mock_response
         mock_client_class.return_value = mock_client
 
         client = PharoClient()
         result = client._make_request(
-            "POST", "/get-class-source", {"class_name": "NonExistentClass"}
+            "GET", "/get-class-source", {"class_name": "NonExistentClass"}
         )
 
         expected = {"success": False, "error": "Class not found: NonExistentClass"}
         assert result == expected
 
     @patch("pharo_smalltalk_interop_mcp_server.core.httpx.Client")
-    def test_make_request_with_non_json_error_response(self, mock_client_class):
-        """Test _make_request handling non-JSON error response (fallback)."""
+    def test_make_request_with_http_error(self, mock_client_class):
+        """Test _make_request handling actual HTTP errors (e.g., server down)."""
         mock_client = Mock()
         mock_response = Mock()
         mock_response.status_code = 500
         mock_response.text = "Internal Server Error"
-        mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
 
         mock_client.post.side_effect = httpx.HTTPStatusError(
             "Server Error", request=Mock(), response=mock_response
@@ -950,9 +942,7 @@ class TestEnhancedErrorHandling:
         mock_client_class.return_value = mock_client
 
         client = PharoClient()
-        result = client._make_request("POST", "/eval", {"code": "invalid"})
+        result = client._make_request("POST", "/eval", {"code": "1 + 1"})
 
-        assert result == {
-            "success": False,
-            "error": "HTTP error 500: Internal Server Error",
-        }
+        expected = {"success": False, "error": "HTTP error 500: Internal Server Error"}
+        assert result == expected

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -252,8 +252,8 @@ class TestPharoIntegration:
 
             if "receiver" in error_data:
                 receiver = error_data["receiver"]
-                assert "class" in receiver
-                assert "self" in receiver
+                assert receiver["class"] == "SmallInteger"
+                assert receiver["self"] == "1"
                 # For 1/0, receiver is SmallInteger (1) which has no instance variables
                 if "variables" in receiver:
                     assert isinstance(receiver["variables"], dict)
@@ -286,8 +286,7 @@ class TestPharoIntegration:
 
             if "receiver" in error_data:
                 receiver = error_data["receiver"]
-                assert "class" in receiver
-                assert "self" in receiver
+                assert receiver["class"] == "Dictionary"
                 # For Dictionary new zork, receiver is Dictionary instance which has instance variables
                 if "variables" in receiver:
                     assert isinstance(receiver["variables"], dict)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -327,9 +327,9 @@ class TestPharoIntegration:
             assert result.startswith("Sis-Tests-Dummy exported to: ")
             # Check the *.st file really exists (search recursively)
             st_files = glob.glob(f"{tmpdir}/**/*.st", recursive=True)
-            assert len(st_files) > 0, (
-                f"No .st file found in {tmpdir} or its subdirectories after export"
-            )
+            assert (
+                len(st_files) > 0
+            ), f"No .st file found in {tmpdir} or its subdirectories after export"
         # Temporary directory is deleted automatically after the with block
 
     def test_list_extended_classes(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -327,9 +327,9 @@ class TestPharoIntegration:
             assert result.startswith("Sis-Tests-Dummy exported to: ")
             # Check the *.st file really exists (search recursively)
             st_files = glob.glob(f"{tmpdir}/**/*.st", recursive=True)
-            assert (
-                len(st_files) > 0
-            ), f"No .st file found in {tmpdir} or its subdirectories after export"
+            assert len(st_files) > 0, (
+                f"No .st file found in {tmpdir} or its subdirectories after export"
+            )
         # Temporary directory is deleted automatically after the with block
 
     def test_list_extended_classes(self):


### PR DESCRIPTION
This pull request introduces comprehensive support for enhanced error handling in the MCP server and its integration with the PharoSmalltalkInteropServer. The changes ensure that both legacy and new, detailed error formats are handled transparently throughout the codebase. Documentation has been updated to describe the new error formats and compatibility, and new tests have been added to verify correct handling of both simple and enhanced error responses, including edge cases.

**Enhanced Error Handling**

* Updated documentation in `CLAUDE.md` to describe support for detailed error information from PharoSmalltalkInteropServer v2.0.0+, including new error response formats, usage, and backward compatibility. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R70) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L90-R141)
* Added explicit note in documentation and code comments that enhanced error handling passes through detailed error information from the Pharo server.

**Testing and Validation**

* Added new unit tests in `tests/test_core.py` to verify handling of enhanced error responses, simple error responses, and HTTP errors in the `PharoClient` class.
* Added integration tests in `tests/test_integration.py` to check correct handling of enhanced and simple error formats for evaluation errors (ZeroDivide, MessageNotUnderstood, syntax errors), including validation of detailed error fields.