### PR TITLE
Add read_screen tool for UI debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ claude mcp add -s user smalltalk-interop -- uv --directory /path/to/pharo-smallt
 
 ### MCP Tools Available
 
-This server provides 19 MCP tools that map to all [PharoSmalltalkInteropServer](https://github.com/mumez/PharoSmalltalkInteropServer/blob/main/spec/openapi.json) APIs:
+This server provides 20 MCP tools that map to all [PharoSmalltalkInteropServer](https://github.com/mumez/PharoSmalltalkInteropServer/blob/main/spec/openapi.json) APIs:
 
 #### Code Evaluation
 
@@ -180,6 +180,128 @@ This server provides 19 MCP tools that map to all [PharoSmalltalkInteropServer](
 
 - **`run_package_test`**: Run test suites for a package
 - **`run_class_test`**: Run test suites for a specific class
+
+#### UI Debugging
+
+- **`read_screen`**: UI screen reader for debugging Pharo interfaces with screenshot and structure extraction
+
+### read_screen Tool
+
+The `read_screen` tool captures screenshots and extracts UI structure for debugging Pharo UI issues.
+
+**Parameters:**
+- `target_type` (string, default: 'world'): UI type to inspect ('world' for morphs, 'spec' for windows, 'roassal' for visualizations)
+- `capture_screenshot` (boolean, default: true): Include PNG screenshot in response
+
+**Returns:** UI structure with screenshot and human-readable summary
+
+**Usage Examples:**
+
+```python
+# Inspect all morphs in World
+read_screen(target_type='world')
+
+# Inspect Spec presenter windows
+read_screen(target_type='spec', capture_screenshot=false)
+
+# Inspect Roassal visualizations without screenshot (faster)
+read_screen(target_type='roassal', capture_screenshot=false)
+```
+
+**Extracted Data Includes:**
+
+*World (morphs):*
+- Class name and type identification
+- Bounds (x, y, width, height coordinates)
+- Visibility state
+- Background color
+- Owner class
+- Submorph count
+- Text content (if available)
+
+Example output:
+```json
+{
+  "totalMorphs": 12,
+  "displayedMorphCount": 1,
+  "morphs": [
+    {
+      "class": "MenubarMorph",
+      "visible": true,
+      "bounds": {"x": 0, "y": 0, "width": 976, "height": 18},
+      "backgroundColor": "(Color r: 0.883... alpha: 0.8)",
+      "owner": "WorldMorph",
+      "submorphCount": 8
+    }
+  ]
+}
+```
+
+*Spec (presenters):*
+- Window title and class name
+- Geometry (extent, position)
+- Window state (maximized, minimized, resizable)
+- Decorations (menu, toolbar, statusbar presence)
+- Presenter hierarchy (recursive with max depth of 3 levels)
+- Presenter class name, child count, and content properties (label, text, value, etc.)
+- Enablement and visibility state
+
+Example output:
+```json
+{
+  "windowCount": 1,
+  "presenters": [
+    {
+      "class": "SpWindowPresenter",
+      "title": "Welcome",
+      "extent": "(700@550)",
+      "hasMenu": false,
+      "presenter": {
+        "class": "StWelcomeBrowser",
+        "childCount": 2,
+        "isVisible": true,
+        "children": []
+      }
+    }
+  ]
+}
+```
+
+*Roassal (visualizations):*
+- Canvas bounds and visibility state
+- Canvas class identification
+- Background color and zoom level
+- Shape details (color, position, extent, label, text)
+- Edge details (source, target, color, label)
+- Node and edge counts
+
+Example output:
+```json
+{
+  "canvasCount": 1,
+  "canvases": [
+    {
+      "class": "RSAthensMorph",
+      "canvasClass": "RSCanvas",
+      "bounds": {"x": 203, "y": 145, "width": 490, "height": 467},
+      "backgroundColor": "Color blue",
+      "zoomLevel": "1.0",
+      "shapeCount": 5,
+      "shapes": [
+        {
+          "class": "RSCircle",
+          "color": "(Color r: 1.0 g: 0.0 b: 0.0 alpha: 0.2)",
+          "position": "(0.0@0.0)",
+          "extent": "(5.0@5.0)"
+        }
+      ],
+      "edgeCount": 0,
+      "edges": [],
+      "nodeCount": 0
+    }
+  ]
+}
+```
 
 ## Development
 
@@ -233,14 +355,14 @@ pharo-smalltalk-interop-mcp-server/
 The test suite uses mock-based testing to ensure:
 
 - **No external dependencies**: Tests run without requiring a live Pharo instance
-- **Comprehensive coverage**: All 19 endpoints and error scenarios are tested
+- **Comprehensive coverage**: All 20 endpoints and error scenarios are tested
 - **Fast execution**: Tests complete in under 1 second
 - **Reliable results**: Tests are deterministic and don't depend on external state
 
 Test coverage includes:
 
 - HTTP client functionality (`PharoClient` class)
-- All 19 Pharo interop operations
+- All 20 Pharo interop operations
 - Error handling (connection errors, HTTP errors, JSON parsing errors)
 - MCP server initialization and tool registration
 - Integration between core functions and MCP tools

--- a/pharo_smalltalk_interop_mcp_server/core.py
+++ b/pharo_smalltalk_interop_mcp_server/core.py
@@ -146,6 +146,18 @@ class PharoClient:
             data["load_groups"] = load_groups
         return self._make_request("GET", "/install-project", data)
 
+    def read_screen(
+        self,
+        target_type: str = "world",
+        capture_screenshot: bool = True,
+    ) -> dict[str, Any]:
+        """Read and inspect Pharo UI structure with screenshot."""
+        data = {
+            "target_type": target_type,
+            "capture_screenshot": capture_screenshot,
+        }
+        return self._make_request("GET", "/read-screen", data)
+
     def close(self):
         """Close the HTTP client."""
         self.client.close()
@@ -285,3 +297,12 @@ def interop_install_project(
     """Install a project using Metacello."""
     client = get_pharo_client()
     return client.install_project(project_name, repository_url, load_groups)
+
+
+def interop_read_screen(
+    target_type: str = "world",
+    capture_screenshot: bool = True,
+) -> dict[str, Any]:
+    """Read and inspect Pharo UI structure with screenshot."""
+    client = get_pharo_client()
+    return client.read_screen(target_type, capture_screenshot)

--- a/pharo_smalltalk_interop_mcp_server/server.py
+++ b/pharo_smalltalk_interop_mcp_server/server.py
@@ -17,6 +17,7 @@ from .core import (
     interop_list_extended_classes,
     interop_list_methods,
     interop_list_packages,
+    interop_read_screen,
     interop_run_class_test,
     interop_run_package_test,
     interop_search_classes_like,
@@ -433,6 +434,35 @@ def install_project(
         - Error: {"success": False, "error": str} - error contains error message
     """
     return interop_install_project(project_name, repository_url, load_groups)
+
+
+@mcp.tool("read_screen")
+def read_screen(
+    _: Context,
+    target_type: Annotated[
+        str, Field(description="UI type to inspect: 'world' (morphs), 'spec' (windows), or 'roassal' (visualizations)")
+    ] = "world",
+    capture_screenshot: Annotated[
+        bool, Field(description="Include PNG screenshot in response")
+    ] = True,
+) -> dict[str, Any]:
+    """
+    Comprehensive UI screen reader for debugging Pharo interfaces.
+
+    Captures screenshot and extracts complete UI structure for World morphs, Spec presenters, and Roassal visualizations.
+
+    Args:
+        target_type: 'world' for morphs, 'spec' for Spec windows, 'roassal' for visualizations
+        capture_screenshot: Include PNG screenshot in response (default: true)
+
+    Returns:
+        dict: UI structure and metrics
+        - screenshot: Path to PNG file in /tmp/ (if capture_screenshot=true)
+        - target_type: Which UI type was inspected
+        - structure: Complete UI hierarchy data
+        - summary: Human-readable description
+    """
+    return interop_read_screen(target_type, capture_screenshot)
 
 
 def main():


### PR DESCRIPTION
Add read_screen MCP tool for UI debugging.

Captures screenshots and extracts UI structure for World morphs, Spec presenters, and Roassal visualizations.

Includes tests and documentation.