### PR TITLE
Release v3.0.0 - UI Debugging Support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ This is a Python-based MCP (Model Context Protocol) server designed to communica
 - **Package Management**: Export and import packages in Tonel format
 - **Project Installation**: Install projects using Metacello
 - **Test Execution**: Run test suites at package or class level
+- **UI Debugging**: Capture screenshots and inspect UI structure for World morphs, Spec presenters, and Roassal visualizations
 
 ## Development Setup
 
@@ -68,13 +69,13 @@ The codebase follows a layered architecture with clean separation of concerns:
    - Connects to `localhost:8086` by default
    - Comprehensive error handling for connection, HTTP, and JSON parsing errors
    - Enhanced error handling supporting detailed error information from PharoSmalltalkInteropServer
-   - 17 core operations mapped to Pharo API endpoints
+   - 18 core operations mapped to Pharo API endpoints
 
 1. **`server.py`** - MCP server layer
 
    - Built on FastMCP framework
    - Decorates core functions with MCP tool registration
-   - Exposes 19 MCP tools covering code evaluation, introspection, search, packages, project installation, and testing
+   - Exposes 20 MCP tools covering code evaluation, introspection, search, packages, project installation, testing, and UI debugging
 
 ### Tool Categories
 
@@ -84,6 +85,7 @@ The codebase follows a layered architecture with clean separation of concerns:
 - **Package Management**: `export_package`, `import_package`, `list_packages`, `list_classes`, `list_extended_classes`, `list_methods`
 - **Project Installation**: `install_project` - Install projects using Metacello
 - **Test Execution**: `run_package_test`, `run_class_test`
+- **UI Debugging**: `read_screen` - Capture screenshots and extract UI structure
 
 ### Key Patterns
 
@@ -139,6 +141,56 @@ MCP tools return error responses directly from the Pharo server. Enhanced errors
 
 The Pharo server uses Python-compatible naming conventions (`stack_trace`, `variables`). No code changes are required when upgrading the Pharo server.
 
+## UI Debugging
+
+The `read_screen` tool provides comprehensive UI inspection capabilities for debugging Pharo interfaces. It captures screenshots and extracts complete UI structure information.
+
+### Supported UI Types
+
+- **`world`**: World morphs (default) - Inspect the Pharo world and all visible morphs
+- **`spec`**: Spec windows - Inspect Spec presenters and their hierarchical structure
+- **`roassal`**: Roassal visualizations - Inspect Roassal canvas elements and shapes
+
+### Parameters
+
+- **`target_type`**: UI type to inspect (default: `"world"`)
+- **`capture_screenshot`**: Include PNG screenshot in response (default: `true`)
+
+### Response Format
+
+```json
+{
+  "success": true,
+  "result": {
+    "screenshot": "/tmp/pharo_screenshot_20250105_123456.png",
+    "target_type": "world",
+    "structure": {
+      "morphs": [...],
+      "count": 42,
+      "details": "..."
+    },
+    "summary": "World contains 42 morphs including..."
+  }
+}
+```
+
+### Usage Example
+
+```python
+# Capture world morphs with screenshot
+result = read_screen(target_type="world", capture_screenshot=True)
+
+# Inspect Spec windows without screenshot
+result = read_screen(target_type="spec", capture_screenshot=False)
+
+# Inspect Roassal visualizations
+result = read_screen(target_type="roassal", capture_screenshot=True)
+```
+
+### Screenshot Storage
+
+Screenshots are saved to `/tmp/` with timestamped filenames: `pharo_screenshot_YYYYMMDD_HHMMSS.png`
+
 ## MCP Integration
 
 The server is designed to be configured in Cursor's mcp.json:
@@ -171,4 +223,4 @@ Note: The `env` section is optional and can be used to set environment variables
 - All operations return structured JSON with success/error status
 - Enhanced error handling passes through detailed error information from Pharo server
 - Comprehensive test suite with mock-based testing to avoid requiring a live Pharo instance
-- Tests cover all 19 endpoints and error scenarios
+- Tests cover all 20 endpoints and error scenarios

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ claude mcp add -s user smalltalk-interop -- uv --directory /path/to/pharo-smallt
 
 ### MCP Tools Available
 
-This server provides 19 MCP tools that map to all [PharoSmalltalkInteropServer](https://github.com/mumez/PharoSmalltalkInteropServer/blob/main/spec/openapi.json) APIs:
+This server provides 20 MCP tools that map to all [PharoSmalltalkInteropServer](https://github.com/mumez/PharoSmalltalkInteropServer/blob/main/spec/openapi.json) APIs:
 
 #### Code Evaluation
 
@@ -180,6 +180,128 @@ This server provides 19 MCP tools that map to all [PharoSmalltalkInteropServer](
 
 - **`run_package_test`**: Run test suites for a package
 - **`run_class_test`**: Run test suites for a specific class
+
+#### UI Debugging
+
+- **`read_screen`**: UI screen reader for debugging Pharo interfaces with screenshot and structure extraction
+
+### read_screen Tool
+
+The `read_screen` tool captures screenshots and extracts UI structure for debugging Pharo UI issues.
+
+**Parameters:**
+- `target_type` (string, default: 'world'): UI type to inspect ('world' for morphs, 'spec' for windows, 'roassal' for visualizations)
+- `capture_screenshot` (boolean, default: true): Include PNG screenshot in response
+
+**Returns:** UI structure with screenshot and human-readable summary
+
+**Usage Examples:**
+
+```python
+# Inspect all morphs in World
+read_screen(target_type='world')
+
+# Inspect Spec presenter windows
+read_screen(target_type='spec', capture_screenshot=false)
+
+# Inspect Roassal visualizations without screenshot (faster)
+read_screen(target_type='roassal', capture_screenshot=false)
+```
+
+**Extracted Data Includes:**
+
+*World (morphs):*
+- Class name and type identification
+- Bounds (x, y, width, height coordinates)
+- Visibility state
+- Background color
+- Owner class
+- Submorph count
+- Text content (if available)
+
+Example output:
+```json
+{
+  "totalMorphs": 12,
+  "displayedMorphCount": 1,
+  "morphs": [
+    {
+      "class": "MenubarMorph",
+      "visible": true,
+      "bounds": {"x": 0, "y": 0, "width": 976, "height": 18},
+      "backgroundColor": "(Color r: 0.883... alpha: 0.8)",
+      "owner": "WorldMorph",
+      "submorphCount": 8
+    }
+  ]
+}
+```
+
+*Spec (presenters):*
+- Window title and class name
+- Geometry (extent, position)
+- Window state (maximized, minimized, resizable)
+- Decorations (menu, toolbar, statusbar presence)
+- Presenter hierarchy (recursive with max depth of 3 levels)
+- Presenter class name, child count, and content properties (label, text, value, etc.)
+- Enablement and visibility state
+
+Example output:
+```json
+{
+  "windowCount": 1,
+  "presenters": [
+    {
+      "class": "SpWindowPresenter",
+      "title": "Welcome",
+      "extent": "(700@550)",
+      "hasMenu": false,
+      "presenter": {
+        "class": "StWelcomeBrowser",
+        "childCount": 2,
+        "isVisible": true,
+        "children": []
+      }
+    }
+  ]
+}
+```
+
+*Roassal (visualizations):*
+- Canvas bounds and visibility state
+- Canvas class identification
+- Background color and zoom level
+- Shape details (color, position, extent, label, text)
+- Edge details (source, target, color, label)
+- Node and edge counts
+
+Example output:
+```json
+{
+  "canvasCount": 1,
+  "canvases": [
+    {
+      "class": "RSAthensMorph",
+      "canvasClass": "RSCanvas",
+      "bounds": {"x": 203, "y": 145, "width": 490, "height": 467},
+      "backgroundColor": "Color blue",
+      "zoomLevel": "1.0",
+      "shapeCount": 5,
+      "shapes": [
+        {
+          "class": "RSCircle",
+          "color": "(Color r: 1.0 g: 0.0 b: 0.0 alpha: 0.2)",
+          "position": "(0.0@0.0)",
+          "extent": "(5.0@5.0)"
+        }
+      ],
+      "edgeCount": 0,
+      "edges": [],
+      "nodeCount": 0
+    }
+  ]
+}
+```
 
 ## Development
 
@@ -233,14 +355,14 @@ pharo-smalltalk-interop-mcp-server/
 The test suite uses mock-based testing to ensure:
 
 - **No external dependencies**: Tests run without requiring a live Pharo instance
-- **Comprehensive coverage**: All 19 endpoints and error scenarios are tested
+- **Comprehensive coverage**: All 20 endpoints and error scenarios are tested
 - **Fast execution**: Tests complete in under 1 second
 - **Reliable results**: Tests are deterministic and don't depend on external state
 
 Test coverage includes:
 
 - HTTP client functionality (`PharoClient` class)
-- All 19 Pharo interop operations
+- All 20 Pharo interop operations
 - Error handling (connection errors, HTTP errors, JSON parsing errors)
 - MCP server initialization and tool registration
 - Integration between core functions and MCP tools

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It supports:
 - Package Management: Export and import packages in Tonel format
 - Project Installation: Install projects using Metacello
 - Test Execution: Run test suites at package or class level
+- UI Debugging: Capture screenshots and inspect UI structure for World morphs, Spec presenters, and Roassal visualizations
 
 ## Prerequisites
 
@@ -190,6 +191,7 @@ This server provides 20 MCP tools that map to all [PharoSmalltalkInteropServer](
 The `read_screen` tool captures screenshots and extracts UI structure for debugging Pharo UI issues.
 
 **Parameters:**
+
 - `target_type` (string, default: 'world'): UI type to inspect ('world' for morphs, 'spec' for windows, 'roassal' for visualizations)
 - `capture_screenshot` (boolean, default: true): Include PNG screenshot in response
 
@@ -211,6 +213,7 @@ read_screen(target_type='roassal', capture_screenshot=false)
 **Extracted Data Includes:**
 
 *World (morphs):*
+
 - Class name and type identification
 - Bounds (x, y, width, height coordinates)
 - Visibility state
@@ -220,6 +223,7 @@ read_screen(target_type='roassal', capture_screenshot=false)
 - Text content (if available)
 
 Example output:
+
 ```json
 {
   "totalMorphs": 12,
@@ -238,6 +242,7 @@ Example output:
 ```
 
 *Spec (presenters):*
+
 - Window title and class name
 - Geometry (extent, position)
 - Window state (maximized, minimized, resizable)
@@ -247,6 +252,7 @@ Example output:
 - Enablement and visibility state
 
 Example output:
+
 ```json
 {
   "windowCount": 1,
@@ -268,6 +274,7 @@ Example output:
 ```
 
 *Roassal (visualizations):*
+
 - Canvas bounds and visibility state
 - Canvas class identification
 - Background color and zoom level
@@ -276,6 +283,7 @@ Example output:
 - Node and edge counts
 
 Example output:
+
 ```json
 {
   "canvasCount": 1,

--- a/pharo_smalltalk_interop_mcp_server/core.py
+++ b/pharo_smalltalk_interop_mcp_server/core.py
@@ -146,6 +146,18 @@ class PharoClient:
             data["load_groups"] = load_groups
         return self._make_request("GET", "/install-project", data)
 
+    def read_screen(
+        self,
+        target_type: str = "world",
+        capture_screenshot: bool = True,
+    ) -> dict[str, Any]:
+        """Read and inspect Pharo UI structure with screenshot."""
+        data = {
+            "target_type": target_type,
+            "capture_screenshot": capture_screenshot,
+        }
+        return self._make_request("GET", "/read-screen", data)
+
     def close(self):
         """Close the HTTP client."""
         self.client.close()
@@ -285,3 +297,12 @@ def interop_install_project(
     """Install a project using Metacello."""
     client = get_pharo_client()
     return client.install_project(project_name, repository_url, load_groups)
+
+
+def interop_read_screen(
+    target_type: str = "world",
+    capture_screenshot: bool = True,
+) -> dict[str, Any]:
+    """Read and inspect Pharo UI structure with screenshot."""
+    client = get_pharo_client()
+    return client.read_screen(target_type, capture_screenshot)

--- a/pharo_smalltalk_interop_mcp_server/server.py
+++ b/pharo_smalltalk_interop_mcp_server/server.py
@@ -17,6 +17,7 @@ from .core import (
     interop_list_extended_classes,
     interop_list_methods,
     interop_list_packages,
+    interop_read_screen,
     interop_run_class_test,
     interop_run_package_test,
     interop_search_classes_like,
@@ -433,6 +434,35 @@ def install_project(
         - Error: {"success": False, "error": str} - error contains error message
     """
     return interop_install_project(project_name, repository_url, load_groups)
+
+
+@mcp.tool("read_screen")
+def read_screen(
+    _: Context,
+    target_type: Annotated[
+        str, Field(description="UI type to inspect: 'world' (morphs), 'spec' (windows), or 'roassal' (visualizations)")
+    ] = "world",
+    capture_screenshot: Annotated[
+        bool, Field(description="Include PNG screenshot in response")
+    ] = True,
+) -> dict[str, Any]:
+    """
+    Comprehensive UI screen reader for debugging Pharo interfaces.
+
+    Captures screenshot and extracts complete UI structure for World morphs, Spec presenters, and Roassal visualizations.
+
+    Args:
+        target_type: 'world' for morphs, 'spec' for Spec windows, 'roassal' for visualizations
+        capture_screenshot: Include PNG screenshot in response (default: true)
+
+    Returns:
+        dict: UI structure and metrics
+        - screenshot: Path to PNG file in /tmp/ (if capture_screenshot=true)
+        - target_type: Which UI type was inspected
+        - structure: Complete UI hierarchy data
+        - summary: Human-readable description
+    """
+    return interop_read_screen(target_type, capture_screenshot)
 
 
 def main():

--- a/pharo_smalltalk_interop_mcp_server/server.py
+++ b/pharo_smalltalk_interop_mcp_server/server.py
@@ -440,7 +440,10 @@ def install_project(
 def read_screen(
     _: Context,
     target_type: Annotated[
-        str, Field(description="UI type to inspect: 'world' (morphs), 'spec' (windows), or 'roassal' (visualizations)")
+        str,
+        Field(
+            description="UI type to inspect: 'world' (morphs), 'spec' (windows), or 'roassal' (visualizations)"
+        ),
     ] = "world",
     capture_screenshot: Annotated[
         bool, Field(description="Include PNG screenshot in response")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pharo-smalltalk-interop-mcp-server"
-version = "0.1.1"
+version = "3.0.0"
 description = "a local MCP server to communicate local Pharo Smalltalk image"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1150,9 +1150,7 @@ class TestInteropFunctions:
 
         assert result == mock_client.read_screen.return_value
         # interop_read_screen calls with positional args
-        mock_client.read_screen.assert_called_once_with(
-            "world", True
-        )
+        mock_client.read_screen.assert_called_once_with("world", True)
 
     @patch("pharo_smalltalk_interop_mcp_server.core.get_pharo_client")
     def test_interop_read_screen_with_parameters(self, mock_get_client):
@@ -1168,9 +1166,7 @@ class TestInteropFunctions:
 
         assert result["success"] is True
         # interop_read_screen calls with positional args
-        mock_client.read_screen.assert_called_once_with(
-            "spec", False
-        )
+        mock_client.read_screen.assert_called_once_with("spec", False)
 
 
 class TestEnhancedErrorHandling:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -553,7 +553,9 @@ class TestPharoIntegration:
         # Screenshot should be a string path
         assert isinstance(screenshot_path, str)
         # File should exist
-        assert os.path.exists(screenshot_path), f"Screenshot not found at {screenshot_path}"
+        assert os.path.exists(screenshot_path), (
+            f"Screenshot not found at {screenshot_path}"
+        )
         # File should have content
         assert os.path.getsize(screenshot_path) > 0
 

--- a/uv.lock
+++ b/uv.lock
@@ -890,7 +890,7 @@ wheels = [
 
 [[package]]
 name = "pharo-smalltalk-interop-mcp-server"
-version = "0.1.1"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
This PR introduces read-screen tool for UI debugging, along with documentation updates and code formatting improvements.

New Features

  - UI Debugging Tool (read_screen): Capture screenshots and inspect UI structure for debugging Pharo
  interfaces
    - Support for World morphs with bounds, visibility, colors, and submorph hierarchy
    - Support for Spec presenters with window state, decorations, and presenter hierarchy
    - Support for Roassal visualizations with canvas, shapes, edges, and node details
    - Optional PNG screenshot capture with timestamped filenames
    - Complete structural data extraction for each UI type

Documentation

  - Updated CLAUDE.md with comprehensive UI debugging documentation
    - Detailed tool description and parameters
    - Response format examples for all UI types
    - Usage examples and screenshot storage information
  - Updated README.md feature list to include UI debugging capability
  - Updated tool counts: 18 core operations, 20 MCP tools

Improvements

  - Fixed code formatting issues with ruff for compliance with line length limits
  - Applied consistent formatting to function arguments and assertion messages

Version

  - Bumped version from 0.1.1 to 3.0.0 (major release for significant new capability)

Testing

  - Comprehensive test coverage for all 20 endpoints including UI debugging functionality
  - Mock-based tests for fast, reliable execution without requiring live Pharo instance