### PR TITLE
Add dockerfile and host env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install runtime deps from your local source (no uv)
+COPY pyproject.toml README.md /app/
+COPY pharo_smalltalk_interop_mcp_server /app/pharo_smalltalk_interop_mcp_server
+
+RUN pip install --no-cache-dir .
+
+ENV PHARO_SIS_URL=http://host.docker.internal:8086
+
+ENTRYPOINT ["pharo-smalltalk-interop-mcp-server"]

--- a/pharo_smalltalk_interop_mcp_server/core.py
+++ b/pharo_smalltalk_interop_mcp_server/core.py
@@ -16,7 +16,9 @@ class PharoInteropError(Exception):
 class PharoClient:
     """HTTP client for communicating with PharoSmalltalkInteropServer."""
 
-    def __init__(self, host: str = "localhost", port: int | None = None):
+    def __init__(self, host: str | None = None, port: int | None = None):
+        if host is None:
+            host = os.getenv("PHARO_SIS_HOST", "localhost")
         if port is None:
             port = int(os.getenv("PHARO_SIS_PORT", "8086"))
         self.base_url = f"http://{host}:{port}"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -55,13 +55,25 @@ class TestPharoClient:
 
     @patch.dict("os.environ", {"PHARO_SIS_PORT": "8081"})
     def test_init_explicit_port_overrides_env(self):
-        """Test that explicit port parameter overrides environment variable."""
+        """Test that explicit port parameter overrides port environment variable."""
         client = PharoClient(port=9999)
         assert client.base_url == "http://localhost:9999"
 
+    @patch.dict("os.environ", {"PHARO_SIS_HOST": "pharo.example"})
+    def test_init_explicit_host_overrides_env(self):
+        """Test that explicit host parameter overrides host environment variable."""
+        client = PharoClient(host="example.com")
+        assert client.base_url == "http://example.com:8086"
+
+    @patch.dict("os.environ", {"PHARO_SIS_HOST": "pharo.example", "PHARO_SIS_PORT": "8081"})
+    def test_init_with_host_and_port_env(self):
+        """Test PharoClient initialization with host and port explicitly set in environment variables."""
+        client = PharoClient()
+        assert client.base_url == "http://pharo.example:8081"
+
     @patch.dict("os.environ", {}, clear=True)
     def test_init_default_port_when_no_env(self):
-        """Test default port is used when no environment variable is set."""
+        """Test default port and host are used when no environment variable is set."""
         client = PharoClient()
         assert client.base_url == "http://localhost:8086"
 


### PR DESCRIPTION
* Added a new `Dockerfile` to build and run the server in a Python 3.12 slim container, supporting environment-based configuration for the Pharo SIS URL.
* Updated the `PharoClient` class in `core.py` to allow the `host` parameter to be set via the `PHARO_SIS_HOST` environment variable, defaulting to `"localhost"` if not provided. The `port` parameter continues to support the `PHARO_SIS_PORT` environment variable.
* Added and updated tests in `test_core.py` to verify that both host and port can be set via environment variables, and that explicit parameters override environment values. Tests also ensure correct defaults when no environment variables are set.