### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ It supports:
 - [uv](https://docs.astral.sh/uv/) package manager
 - Pharo with [PharoSmalltalkInteropServer](https://github.com/mumez/PharoSmalltalkInteropServer) installed
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/mumez-pharo-smalltalk-interop-mcp-server).
+
 ## Installation
 
 ### Quick Start (using uvx)


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/mumez-pharo-smalltalk-interop-mcp-server)